### PR TITLE
Add support for vanilla and bionic icons texture

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -14,6 +14,9 @@
   </supportedVersions>
   <modDependencies />
   <loadAfter />
+  <loadBefore>
+	  <li>automatic.bionicicons</li>
+  </loadBefore>
   <description>[img]https://i.imgur.com/buuPQel.png[/img]
 Update of LingLuos mod
 https://steamcommunity.com/sharedfiles/filedetails/?id=1208746347

--- a/Defs/Items_BodyParts.xml
+++ b/Defs/Items_BodyParts.xml
@@ -2,7 +2,7 @@
 <Defs>
   <ThingDef ParentName="BodyPartNaturalBase" Name="LingBodyPartNaturalBase" Abstract="True">
     <graphicData>
-      <texPath>Things/Item/BodyPart/LingOrgan</texPath>
+      <texPath>Things/Item/Health/HealthItem</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <drawGUIOverlay>true</drawGUIOverlay>


### PR DESCRIPTION
It uses now the same vanilla texture as the vanilla body parts like Heart (here, I think it adds coherent with core body parts) and so adds support for mod replacing the core texture like Bionic Icons.


With core texture and no other mod
<img width="506" height="411" alt="image" src="https://github.com/user-attachments/assets/38567055-8ba4-4d98-93e8-495d128474cf" />

With Bionic Icons mod textures
There is issue with Bionics Icons texture mapping but this have to be modified on their side for finger (having hand icon), head and neck (having no texture replacement).
<img width="502" height="399" alt="image" src="https://github.com/user-attachments/assets/50bc5d72-deb3-4a88-a948-fc65e8a73192" />