### PR TITLE
Wrong body part for finger

### DIFF
--- a/Defs/Recipes_Surgery_Installations.xml
+++ b/Defs/Recipes_Surgery_Installations.xml
@@ -203,7 +203,7 @@
       </thingDefs>
     </fixedIngredientFilter>
     <appliedOnFixedBodyParts>
-      <li>Hand</li>
+      <li>Finger</li>
     </appliedOnFixedBodyParts>
   </RecipeDef>
   <RecipeDef ParentName="SurgeryFleshHuman">


### PR DESCRIPTION
During testing to push an update of Bionic Icons mod for the few ones having issue, I find the finger is set to be applied on Hand instead of Finger body part.

It was preventing to install a Finger when one is missing and instead allow to install a Finger to fix a missing hand.
That also why Bionic Icons use a hand instead of a finger texture.